### PR TITLE
Adding methods to retrieve and alter torrents by hash

### DIFF
--- a/torrent_rename_path.go
+++ b/torrent_rename_path.go
@@ -27,10 +27,35 @@ func (c *Client) TorrentRenamePath(payload *TorrentRenamePathPayload) (err error
 	return
 }
 
+// TorrentRenamePathHash allows to rename torrent name or path by its hash.
+// https://github.com/transmission/transmission/blob/2.9x/extras/rpc-spec.txt#L440
+func (c *Client) TorrentRenamePathHash(payload *TorrentRenamePathHashPayload) (err error) {
+	// Validate
+	if payload == nil {
+		return errors.New("payload can't be nil")
+	}
+	if len(payload.IDs) != 1 {
+		return errors.New("there must be one and only one ID")
+	}
+	// Send payload
+	if err = c.rpcCall("torrent-rename-path", payload, nil); err != nil {
+		err = fmt.Errorf("'torrent-rename-path' rpc method failed: %v", err)
+	}
+	return
+}
+
 // TorrentRenamePathPayload describes the torrents' id(s) and other options.
 // https://github.com/transmission/transmission/blob/2.9x/extras/rpc-spec.txt#L447
 type TorrentRenamePathPayload struct {
 	IDs  []int64 `json:"ids"`  // the torrent torrent list, as described in 3.1 (must only be 1 torrent)
 	Path string  `json:"path"` // the path to the file or folder that will be renamed
 	Name string  `json:"name"` // the file or folder's new name
+}
+
+// TorrentRenamePathHashPayload describes the torrent id (by hash) and other options.
+// https://github.com/transmission/transmission/blob/2.9x/extras/rpc-spec.txt#L447
+type TorrentRenamePathHashPayload struct {
+	IDs  []string `json:"ids"`  // the torrent torrent list, as described in 3.1 (must only be 1 torrent)
+	Path string   `json:"path"` // the path to the file or folder that will be renamed
+	Name string   `json:"name"` // the file or folder's new name
 }

--- a/torrent_set_location.go
+++ b/torrent_set_location.go
@@ -27,10 +27,35 @@ func (c *Client) TorrentSetLocation(payload *TorrentSetLocationPayload) (err err
 	return
 }
 
+// TorrentSetLocationHash allows to set a new location for one or more torrents.
+// https://github.com/transmission/transmission/blob/2.9x/extras/rpc-spec.txt#L423
+func (c *Client) TorrentSetLocationHash(payload *TorrentSetLocationHashPayload) (err error) {
+	// Validate
+	if payload == nil {
+		return errors.New("payload can't be nil")
+	}
+	if len(payload.IDs) == 0 {
+		return errors.New("there must be at least one ID")
+	}
+	// Send payload
+	if err = c.rpcCall("torrent-set-location", payload, nil); err != nil {
+		err = fmt.Errorf("'torrent-set-location' rpc method failed: %v", err)
+	}
+	return
+}
+
 // TorrentSetLocationPayload describes the torrents' id(s) and other options.
 // https://github.com/transmission/transmission/blob/2.9x/extras/rpc-spec.txt#L427
 type TorrentSetLocationPayload struct {
 	IDs      []int64 `json:"ids"`      // torrent list
 	Location string  `json:"location"` // the new torrent location
 	Move     bool    `json:"move"`     // if true, move from previous location. Otherwise, search "location" for files
+}
+
+// TorrentSetLocationHashPayload describes the torrent id (by hash) and other options.
+// https://github.com/transmission/transmission/blob/2.9x/extras/rpc-spec.txt#L427
+type TorrentSetLocationHashPayload struct {
+	IDs      []string `json:"ids"`      // torrent list
+	Location string   `json:"location"` // the new torrent location
+	Move     bool     `json:"move"`     // if true, move from previous location. Otherwise, search "location" for files
 }


### PR DESCRIPTION
What has been added:

- TorrentRenamePathHash
- TorrentSetLocationHash
- TorrentGetAllForHashes
- TorrentGetHashes

I've stopped because I feel like I'm copy-pasting too much code, so I prefer you check it before I do anything else.

BTW, I think that would be ideal to create a struct or use some kind of map to be able to use the exact same methods, but with different kind of ids.

refs #4
