### PR TITLE
Support RPC version 16

### DIFF
--- a/session_arguments.go
+++ b/session_arguments.go
@@ -46,6 +46,7 @@ func (c *Client) SessionArgumentsSet(payload *SessionArguments) (err error) {
 	payload.ConfigDir = nil
 	payload.RPCVersion = nil
 	payload.RPCVersionMinimum = nil
+	payload.SessionID = nil
 	payload.Version = nil
 	// Exec
 	if err = c.rpcCall("session-set", payload, nil); err != nil {
@@ -105,6 +106,7 @@ type SessionArguments struct {
 	SeedRatioLimited          *bool    `json:"seedRatioLimited"`             // true if seedRatioLimit is honored by default
 	SeedQueueSize             *int64   `json:"seed-queue-size"`              // max number of torrents to uploaded at once (see seed-queue-enabled)
 	SeedQueueEnabled          *bool    `json:"seed-queue-enabled"`           // if true, limit how many torrents can be uploaded at once
+	SessionID                 *string  `json:"session-id"`                   // the current session ID
 	SpeedLimitDown            *int64   `json:"speed-limit-down"`             // max global download speed (KBps)
 	SpeedLimitDownEnabled     *bool    `json:"speed-limit-down-enabled"`     // true means enabled
 	SpeedLimitUp              *int64   `json:"speed-limit-up"`               // max global upload speed (KBps)

--- a/torrent_accessors.go
+++ b/torrent_accessors.go
@@ -135,6 +135,7 @@ type Torrent struct {
 	DownloadedEver          *int64             `json:"downloadedEver"`
 	DownloadLimit           *int64             `json:"downloadLimit"`
 	DownloadLimited         *bool              `json:"downloadLimited"`
+	EditDate                *time.Time         `json:"editDate"`
 	Error                   *int64             `json:"error"`
 	ErrorString             *string            `json:"errorString"`
 	Eta                     *int64             `json:"eta"`
@@ -218,6 +219,7 @@ func (t *Torrent) UnmarshalJSON(data []byte) (err error) {
 		AddedDate      *int64  `json:"addedDate"`
 		DateCreated    *int64  `json:"dateCreated"`
 		DoneDate       *int64  `json:"doneDate"`
+		EditDate       *int64  `json:"editDate"`
 		PieceSize      *int64  `json:"pieceSize"`
 		SecondsSeeding *int64  `json:"secondsSeeding"`
 		SizeWhenDone   *int64  `json:"sizeWhenDone"`
@@ -248,6 +250,10 @@ func (t *Torrent) UnmarshalJSON(data []byte) (err error) {
 	if tmp.DoneDate != nil {
 		dd := time.Unix(*tmp.DoneDate, 0)
 		t.DoneDate = &dd
+	}
+	if tmp.EditDate != nil {
+		dd := time.Unix(*tmp.EditDate, 0)
+		t.EditDate = &dd
 	}
 	if tmp.PieceSize != nil {
 		ps := cunits.ImportInByte(float64(*tmp.PieceSize))

--- a/torrent_accessors.go
+++ b/torrent_accessors.go
@@ -120,6 +120,7 @@ type torrentGetResults struct {
 // Torrent represents all the possible fields of data for a torrent.
 // All fields are pointers to detect if the value is nil (field not requested) or default real default value.
 // https://github.com/transmission/transmission/blob/2.9x/extras/rpc-spec.txt#L163
+// https://github.com/transmission/transmission/blob/3.00/extras/rpc-spec.txt#L178
 type Torrent struct {
 	ActivityDate            *time.Time         `json:"activityDate"`
 	AddedDate               *time.Time         `json:"addedDate"`
@@ -148,6 +149,7 @@ type Torrent struct {
 	IsFinished              *bool              `json:"isFinished"`
 	IsPrivate               *bool              `json:"isPrivate"`
 	IsStalled               *bool              `json:"isStalled"`
+	Labels                  []string           `json:"labels"` // RPC v16
 	LeftUntilDone           *int64             `json:"leftUntilDone"`
 	MagnetLink              *string            `json:"magnetLink"`
 	ManualAnnounceTime      *int64             `json:"manualAnnounceTime"`

--- a/torrent_mutators.go
+++ b/torrent_mutators.go
@@ -32,6 +32,7 @@ func (c *Client) TorrentSet(payload *TorrentSetPayload) (err error) {
 
 // TorrentSetPayload contains all the mutators appliable on one torrent.
 // https://github.com/transmission/transmission/blob/2.9x/extras/rpc-spec.txt#L111
+// https://github.com/transmission/transmission/blob/3.00/extras/rpc-spec.txt#L111
 type TorrentSetPayload struct {
 	BandwidthPriority   *int64         `json:"bandwidthPriority"`   // this torrent's bandwidth tr_priority_t
 	DownloadLimit       *int64         `json:"downloadLimit"`       // maximum download speed (KBps)
@@ -40,6 +41,7 @@ type TorrentSetPayload struct {
 	FilesUnwanted       []int64        `json:"files-unwanted"`      // indices of file(s) to not download
 	HonorsSessionLimits *bool          `json:"honorsSessionLimits"` // true if session upload limits are honored
 	IDs                 []int64        `json:"ids"`                 // torrent list
+	Labels              []string       `json:"labels"`              // RPC v16: strings of user-defined labels
 	Location            *string        `json:"location"`            // new location of the torrent's content
 	PeerLimit           *int64         `json:"peer-limit"`          // maximum number of peers
 	PriorityHigh        []int64        `json:"priority-high"`       // indices of high-priority file(s)


### PR DESCRIPTION
This is an attempt to address #13 

I think it's very important to maintain compatibility with version 15 so that clients can use the same version of this package for both transmission 2.94 and 3.0.

I've added each "feature" in separate commits for easy review. Will squash if necessary:

- Add support for labels: user-defined arbitrary label strings like "iso" or "linux" can be added to torrents.

- lastScrapeTimedOut as pointed out in #13 now yields a bool instead of float64.

- editDate field: This field is set when a significant edit is made to the torrent such as renaming a file. Simple mutations like get/no-get don't update this field.

- session-id field. This field seems to be specifically for the transmission-qt to identify whether it's local or not.

There are two more things added in 3.0 which I haven't yet addressed as they're quite substantial. I can work on them in a separate PR or keep this PR open until they're done:

-  "fields" argument in session-get. This is analogous to the "fields" in torrent-get so that you can request a subset of the fields.

- "format" argument in torrent-get. The default is "objects" and keeps the 2.94 behaviour of returning json objects. "table" results in an array of array: https://github.com/transmission/transmission/blob/3.00/extras/rpc-spec.txt#L151-L168


Other than the `lastScrapeTimedOut` issue, the other changes seem to be documented. I also tested `torrent-get` with all fields against 2.94 and 3.00 to ensure there were no other breaking changes. I haven't yet tested other accessors and mutators. Either way, this PR should be a good move towards full 16 support and only improves compatibility.

Anyway, please let me know if you'd like changes/additions/etc., thanks!
