### PR TITLE
Use thread-safe random generator

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -29,7 +29,6 @@ type Client struct {
 	sessionID       string
 	sessionIDAccess sync.RWMutex
 	userAgent       string
-	rnd             *rand.Rand
 	httpC           *http.Client
 	debug           bool
 }
@@ -85,13 +84,14 @@ func New(host, user, password string, conf *AdvancedConfig) (c *Client, err erro
 		err = fmt.Errorf("can't build a valid URL: %v", err)
 		return
 	}
+	rand.Seed(time.Now().UnixNano())
+
 	// Initialize & return ready to use client
 	c = &Client{
 		url:       remoteURL.String(),
 		user:      user,
 		password:  password,
 		userAgent: conf.UserAgent,
-		rnd:       rand.New(rand.NewSource(time.Now().Unix())),
 		httpC:     cleanhttp.DefaultPooledClient(),
 		debug:     conf.Debug,
 	}

--- a/controller.go
+++ b/controller.go
@@ -99,7 +99,6 @@ func New(host, user, password string, conf *AdvancedConfig) (c *Client, err erro
 	return
 }
 
-
 // rand.NewSource is not thread-safe, so access should be serialized
 type lockedRandomSource struct {
 	sync.Mutex

--- a/controller.go
+++ b/controller.go
@@ -85,7 +85,6 @@ func New(host, user, password string, conf *AdvancedConfig) (c *Client, err erro
 		err = fmt.Errorf("can't build a valid URL: %v", err)
 		return
 	}
-
 	// Initialize & return ready to use client
 	c = &Client{
 		url:       remoteURL.String(),

--- a/controller.go
+++ b/controller.go
@@ -84,6 +84,8 @@ func New(host, user, password string, conf *AdvancedConfig) (c *Client, err erro
 		err = fmt.Errorf("can't build a valid URL: %v", err)
 		return
 	}
+
+	// Seed random generator to be used by Client
 	rand.Seed(time.Now().UnixNano())
 
 	// Initialize & return ready to use client

--- a/request.go
+++ b/request.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"os"
 	"sync"
@@ -54,7 +55,7 @@ func (c *Client) request(method string, arguments interface{}, result interface{
 	var mg sync.WaitGroup
 	mg.Add(1)
 	go func() {
-		tag = c.rnd.Int()
+		tag = rand.Int()
 		encErr = json.NewEncoder(pIn).Encode(&requestPayload{
 			Method:    method,
 			Arguments: arguments,

--- a/request.go
+++ b/request.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"net/http"
 	"os"
 	"sync"
@@ -55,7 +54,7 @@ func (c *Client) request(method string, arguments interface{}, result interface{
 	var mg sync.WaitGroup
 	mg.Add(1)
 	go func() {
-		tag = rand.Int()
+		tag = c.rnd.Int()
 		encErr = json.NewEncoder(pIn).Encode(&requestPayload{
 			Method:    method,
 			Arguments: arguments,


### PR DESCRIPTION
Go race detector detects an issue with random generator:
```
==================
WARNING: DATA RACE
Read at 0x00c0003e6000 by goroutine 186:
  math/rand.(*rngSource).Uint64()
      /usr/local/go/src/math/rand/rng.go:239 +0x3e
  math/rand.(*rngSource).Int63()
      /usr/local/go/src/math/rand/rng.go:234 +0x1d9
  math/rand.(*Rand).Int63()
      /usr/local/go/src/math/rand/rand.go:85 +0x8e
  math/rand.(*Rand).Int()
      /usr/local/go/src/math/rand/rand.go:103 +0x6f
  github.com/hekmon/transmissionrpc.(*Client).request.func1()
      go/src/github.com/hekmon/transmissionrpc/request.go:57 +0x45

Previous write at 0x00c0003e6000 by goroutine 181:
  math/rand.(*rngSource).Uint64()
      /usr/local/go/src/math/rand/rng.go:239 +0x54
  math/rand.(*rngSource).Int63()
      /usr/local/go/src/math/rand/rng.go:234 +0x1d9
  math/rand.(*Rand).Int63()
      /usr/local/go/src/math/rand/rand.go:85 +0x8e
  math/rand.(*Rand).Int()
      /usr/local/go/src/math/rand/rand.go:103 +0x6f
  github.com/hekmon/transmissionrpc.(*Client).request.func1()
      go/src/github.com/hekmon/transmissionrpc/request.go:57 +0x45
```

From https://golang.org/pkg/math/rand/
> The default Source is safe for concurrent use by multiple goroutines, but Sources created by NewSource are not.


