### PR TITLE
Allow custom http Client

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -46,20 +46,37 @@ type AdvancedConfig struct {
 	Debug       bool
 }
 
-// NewClient is the new entry into this module. URL, user and password are required.
-// The http client is optional, but recommended.
-func NewClient(url, user, password string, client *http.Client) *Client {
-	if client == nil {
-		client = &http.Client{Timeout: defaultTimeout}
+// Config is the input data needed to make a connection a Transmission RPC.
+type Config struct {
+	// URL should be a full url to the /transmission/rpc endpoint.
+	URL string
+	// Username if authentication is required.
+	Username string
+	// Password if authentication is required.
+	Password string
+	// UserAgent is set to this package's url if not provided.
+	UserAgent string
+	// Client is set to a default http.Client with a sane timeout if not provided.
+	Client *http.Client
+}
+
+// NewClient is the new entry into this module.
+func NewClient(config Config) *Client {
+	if config.Client == nil {
+		config.Client = &http.Client{Timeout: defaultTimeout}
+	}
+
+	if config.UserAgent == "" {
+		config.UserAgent = defaultUserAgent
 	}
 
 	return &Client{
-		url:       url,
-		user:      user,
-		password:  password,
-		userAgent: defaultUserAgent, // not configurable, and that's ok.
+		url:       config.URL,
+		user:      config.Username,
+		password:  config.Password,
+		userAgent: config.UserAgent,
 		rnd:       rand.New(newLockedRandomSource(time.Now().Unix())),
-		httpC:     client,
+		httpC:     config.Client,
 		// If you need debug, use a custom transport/roundtripper in your http client.
 		// Ex: https://pkg.go.dev/golift.io/starr@main/debuglog
 		debug: false,

--- a/controller.go
+++ b/controller.go
@@ -46,7 +46,7 @@ type AdvancedConfig struct {
 	Debug       bool
 }
 
-// Config is the input data needed to make a connection a Transmission RPC.
+// Config is the input data needed to make a connection to Transmission RPC.
 type Config struct {
 	// URL should be a full url to the /transmission/rpc endpoint.
 	URL string
@@ -54,13 +54,14 @@ type Config struct {
 	Username string
 	// Password if authentication is required.
 	Password string
-	// UserAgent is set to this package's url if not provided.
+	// UserAgent is set to this package's url if not provided here.
 	UserAgent string
-	// Client is set to a default http.Client with a sane timeout if not provided.
+	// Client is set to an empty http.Client{} with a sane timeout if not provided.
 	Client *http.Client
 }
 
-// NewClient is the new entry into this module.
+// NewClient is the new entry into this module. Provide a Config with at minimum a URL.
+// The Client returned may be used to query the Transmission RPC.
 func NewClient(config Config) *Client {
 	if config.Client == nil {
 		config.Client = &http.Client{Timeout: defaultTimeout}
@@ -77,7 +78,7 @@ func NewClient(config Config) *Client {
 		userAgent: config.UserAgent,
 		rnd:       rand.New(newLockedRandomSource(time.Now().Unix())),
 		httpC:     config.Client,
-		// If you need debug, use a custom transport/roundtripper in your http client.
+		// If you need debug, use a custom transport/roundtripper in your http.Client.
 		// Ex: https://pkg.go.dev/golift.io/starr@main/debuglog
 		debug: false,
 	}

--- a/controller.go
+++ b/controller.go
@@ -46,6 +46,26 @@ type AdvancedConfig struct {
 	Debug       bool
 }
 
+// NewClient is the new entry into this module. URL, user and password are required.
+// The http client is optional, but recommended.
+func NewClient(url, user, password string, client *http.Client) *Client {
+	if client == nil {
+		client = &http.Client{Timeout: defaultTimeout}
+	}
+
+	return &Client{
+		url:       url,
+		user:      user,
+		password:  password,
+		userAgent: defaultUserAgent, // not configurable, and that's ok.
+		rnd:       rand.New(newLockedRandomSource(time.Now().Unix())),
+		httpC:     client,
+		// If you need debug, use a custom transport/roundtripper in your http client.
+		// Ex: https://pkg.go.dev/golift.io/starr@main/debuglog
+		debug: false,
+	}
+}
+
 // New returns an initialized and ready to use Controller
 func New(host, user, password string, conf *AdvancedConfig) (c *Client, err error) {
 	// Config

--- a/controller_test.go
+++ b/controller_test.go
@@ -11,10 +11,11 @@ func TestNew(t *testing.T) {
 	t.Parallel()
 
 	expect := &Client{
-		httpC:    &http.Client{Timeout: defaultTimeout},
-		user:     "localuser",
-		password: "localpass",
-		url:      fmt.Sprint("http://localhost:", defaultPort, defaultRPCPath),
+		httpC:     &http.Client{Timeout: defaultTimeout},
+		user:      "localuser",
+		password:  "localpass",
+		url:       fmt.Sprint("http://localhost:", defaultPort, defaultRPCPath),
+		userAgent: defaultUserAgent,
 	}
 
 	client, err := New("localhost", expect.user, expect.password, nil)
@@ -29,19 +30,25 @@ func TestNewClient(t *testing.T) {
 	t.Parallel()
 
 	expect := &Client{
-		httpC:    &http.Client{Timeout: defaultTimeout},
-		user:     "localuser",
-		password: "localpass",
-		url:      "http://localhost:999/rpc",
-		debug:    false,
+		httpC:     &http.Client{Timeout: defaultTimeout},
+		user:      "localuser",
+		password:  "localpass",
+		url:       "http://localhost:999/rpc",
+		debug:     false,
+		userAgent: "test agent",
+	}
+	config := Config{
+		URL:       expect.url,
+		Username:  expect.user,
+		Password:  expect.password,
+		UserAgent: expect.userAgent,
 	}
 
-	client := NewClient(expect.url, expect.user, expect.password, nil)
-	testCheckClient(t, client, expect)
+	testCheckClient(t, NewClient(config), expect)
 
 	expect.httpC.Timeout = time.Hour
-	client = NewClient(expect.url, expect.user, expect.password, expect.httpC)
-	testCheckClient(t, client, expect)
+	config.Client = &http.Client{Timeout: time.Hour}
+	testCheckClient(t, NewClient(config), expect)
 }
 
 func testCheckClient(t *testing.T, received *Client, expected *Client) {
@@ -64,6 +71,10 @@ func testCheckClient(t *testing.T, received *Client, expected *Client) {
 
 	if received.url != expected.url {
 		t.Error("Provided client was returned with the wrong URL.")
+	}
+
+	if received.userAgent != expected.userAgent {
+		t.Error("Provided client was returned with the wrong User Agent.")
 	}
 
 	if received.httpC.Timeout != expected.httpC.Timeout {

--- a/controller_test.go
+++ b/controller_test.go
@@ -1,0 +1,76 @@
+package transmissionrpc
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	expect := &Client{
+		httpC:    &http.Client{Timeout: defaultTimeout},
+		user:     "localuser",
+		password: "localpass",
+		url:      fmt.Sprint("http://localhost:", defaultPort, defaultRPCPath),
+	}
+
+	client, err := New("localhost", expect.user, expect.password, nil)
+	if err != nil {
+		t.Fatalf("Requesting a simple rpc client must not produce an error: %v", err)
+	}
+
+	testCheckClient(t, client, expect)
+}
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+
+	expect := &Client{
+		httpC:    &http.Client{Timeout: defaultTimeout},
+		user:     "localuser",
+		password: "localpass",
+		url:      "http://localhost:999/rpc",
+		debug:    false,
+	}
+
+	client := NewClient(expect.url, expect.user, expect.password, nil)
+	testCheckClient(t, client, expect)
+
+	expect.httpC.Timeout = time.Hour
+	client = NewClient(expect.url, expect.user, expect.password, expect.httpC)
+	testCheckClient(t, client, expect)
+}
+
+func testCheckClient(t *testing.T, received *Client, expected *Client) {
+	t.Helper()
+
+	switch {
+	case received == nil:
+		t.Fatal("Requesting a rpc client must not produce a nil client.")
+	case received.httpC == nil:
+		t.Fatal("Requesting a rpc client must not produce a nil http client.")
+	}
+
+	if received.password != expected.password {
+		t.Error("Provided client was returned with the wrong password.")
+	}
+
+	if received.user != expected.user {
+		t.Error("Provided client was returned with the wrong username.")
+	}
+
+	if received.url != expected.url {
+		t.Error("Provided client was returned with the wrong URL.")
+	}
+
+	if received.httpC.Timeout != expected.httpC.Timeout {
+		t.Error("Provided client was returned with the wrong http timeout.")
+	}
+
+	if received.debug != expected.debug {
+		t.Error("Provided client was returned with the wrong debug setting.")
+	}
+}


### PR DESCRIPTION
- Closes #23
- Allows passing in an `http.Client`.
- No breaking changes.
- Adds very rudimentary tests.